### PR TITLE
Name update

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ Verify the functionality of the PMPS system via the ADS interface
 
 After installing run the following command to see the basic tests:
 
-`do_test`
+`pmps_run_tests`
 
 To see an example of passing a parameter to the tests at runtime, run the following command:
 
-`do_test --ams_net_id 127.0.0.1.1.1`
+`pmps_run_tests --ams_net_id 127.0.0.1.1.1`
 
 To see an example of a parameter passed to pytest programmatically, see the use of CMDOPT_OPTION in `pmps_test/pmps/main.py`.
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ pip install --upgrade pip
 
 here = path.abspath(path.dirname(__file__))
 
-with open(path.join(here, 'README.rst'), encoding='utf-8') as readme_file:
+with open(path.join(here, 'README.md'), encoding='utf-8') as readme_file:
     readme = readme_file.read()
 
 with open(path.join(here, 'requirements.txt')) as requirements_file:

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     url='https://github.com/pcdshub/pmps_test',
     entry_points={
         'console_scripts': [
-                "do_test = pmps_test.bin.main:main",
+                "pmps_run_tests = pmps_test.bin.main:main",
             ],
         },
     include_package_data=True,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Use `pmps_run_tests` as new command. Resolves issue #1.

## Motivation and Context
The old command name (`do_test`) is much too vague.

## How Has This Been Tested?
Package has been reinstalled locally 
